### PR TITLE
0.6.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '10'
+- '11'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '10'
+- '11'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 zip_keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -33,9 +33,9 @@ CONDARC
 
 
 mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+    conda-build pip boa conda-forge-ci-setup=3 "py-lief<0.12"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Summary: The FEniCSx Form Compiler
 
 Development: https://github.com/fenics/ffcx
 
-Documentation: https://docs.fenicsproject.org/ffcx/v0.5.0/
+Documentation: https://docs.fenicsproject.org/ffcx/v0.6.0/
 
 FFCx is a new version of the FEniCS Form Compiler.
 It is being actively developed and is compatible with DOLFINx.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,22 +1,20 @@
 {% set name = "fenics-ffcx-ufcx" %}
-{% set version = "0.5.0" %}
+{% set version = "0.6.0" %}
 
 # pins are usually updated on minor bumps:
 # basix is currently co-versioned with ffcx
 {% set major_minor = version.rsplit(".", 1)[0] %}
-{% set ufl_version = "2022.2" %}
+{% set ufl_version = "2023.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  # PyPI sdist missing ufcx sources in 0.4.2. Should be fixed in 0.4.3
-  # url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}{{ extra }}.tar.gz
   url: https://github.com/fenics/ffcx/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 3413409e5885e41e220f99e0f95cc817e94c4931143d1f700c6e0c5e1bfad1f6
+  sha256: 076fad61d406afffd41019ae1abf6da3f76406c035c772abad2156127667980e
 build:
-  number: 1
+  number: 0
   skip: true  # [win]
 
 outputs:


### PR DESCRIPTION
upstream: https://github.com/FEniCS/ffcx/compare/v0.5.0...v0.6.0

needs https://github.com/conda-forge/fenics-basix-feedstock/pull/9